### PR TITLE
add-auth-signin-signout-and-proxy

### DIFF
--- a/src/commands/auth/signin.ts
+++ b/src/commands/auth/signin.ts
@@ -1,3 +1,23 @@
-import type { LocalContext } from "../../context";
+import type { LocalContext } from "../../types";
+import { ExitCode } from "../../types";
 
-export async function signin(this: LocalContext): Promise<void> {}
+export async function signin(this: LocalContext): Promise<void> {
+	const user = await this.user();
+
+	this.process.stdout.write("Signing in...\n");
+
+	try {
+		const user = await this.signIn();
+
+		if (user) {
+			this.process.stdout.write(`Signed in as ${user.profile.email}\n`);
+			this.process.exit(ExitCode.SUCCESS);
+		} else {
+			this.process.stderr.write("Sign in failed!\n");
+			this.process.exit(ExitCode.FAILURE);
+		}
+	} catch (error) {
+		this.process.stderr.write("Sign in errored!\n");
+		this.process.exit(ExitCode.ERROR);
+	}
+}

--- a/src/commands/auth/signout.ts
+++ b/src/commands/auth/signout.ts
@@ -1,3 +1,15 @@
-import type { LocalContext } from "../../context";
+import type { LocalContext } from "../../types";
+import { ExitCode } from "../../types";
 
-export async function signout(this: LocalContext): Promise<void> {}
+export async function signout(this: LocalContext): Promise<void> {
+	const user = await this.user();
+
+	if (user) {
+		await this.signOut();
+		this.process.stdout.write(`Signed out ${user.profile.email}\n`);
+		this.process.exit(ExitCode.SUCCESS);
+	} else {
+		this.process.stdout.write("Not signed in\n");
+		this.process.exit(ExitCode.UNAUTHORIZED);
+	}
+}

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -1,3 +1,15 @@
-import type { LocalContext } from "../../context";
+import type { LocalContext } from "../../types";
+import { ExitCode } from "../../types";
 
-export async function status(this: LocalContext): Promise<void> {}
+export async function status(this: LocalContext): Promise<void> {
+	const user = await this.user();
+
+	if (user) {
+		this.process.stdout.write(`Signed in as ${user.profile.email}\n`);
+		this.process.exit(ExitCode.SUCCESS);
+	} else {
+		this.process.stdout.write("Not Signed In\n");
+		this.process.stdout.write("Run 'pylee auth signin' to authenticate.\n");
+		this.process.exit(ExitCode.UNAUTHORIZED);
+	}
+}

--- a/src/commands/proxy/proxy.ts
+++ b/src/commands/proxy/proxy.ts
@@ -1,3 +1,11 @@
-import type { LocalContext } from "../../context";
+import { MCPProxyServer } from "@pyleeai/mcp-proxy-server";
+import type { LocalContext } from "../../types";
 
-export default async function (this: LocalContext): Promise<void> {}
+export default async function (this: LocalContext): Promise<void> {
+	const user = await this.user();
+
+	const configurationUrl = user?.profile?.private_metadata
+		?.configurationUrl as string;
+
+	using proxy = await MCPProxyServer(configurationUrl);
+}

--- a/src/commands/setup/setup.ts
+++ b/src/commands/setup/setup.ts
@@ -1,3 +1,3 @@
-import type { LocalContext } from "../../context";
+import type { LocalContext } from "../../types";
 
 export default async function (this: LocalContext): Promise<void> {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,3 +47,12 @@ export interface LocalContext
 	signIn: () => Promise<User | null>;
 	signOut: () => Promise<void>;
 }
+
+export const ExitCode = {
+	SUCCESS: 0,
+	ERROR: 1,
+	FAILURE: 2,
+	UNAUTHORIZED: -4,
+} as const;
+
+export type ExitCode = (typeof ExitCode)[keyof typeof ExitCode];

--- a/tests/commands/README.md
+++ b/tests/commands/README.md
@@ -1,0 +1,5 @@
+# Command Testing in Stricli
+
+This directory contains tests for CLI commands implemented using the Stricli framework.
+
+See [Stricli Testing](https://bloomberg.github.io/stricli/docs/testing) for testing details and practices.

--- a/tests/commands/auth/signin/signin.test.ts
+++ b/tests/commands/auth/signin/signin.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, mock, test } from "bun:test";
+import { signin } from "../../../../src/commands/auth/signin";
+import type { User } from "../../../../src/types";
+import { ExitCode } from "../../../../src/types";
+import { buildContextForTest } from "../../../helpers/context.test";
+
+describe("auth signin", () => {
+	describe("when user is signed in", () => {
+		test("informs the user they are signed in", async () => {
+			// Arrange
+			const user = {
+				profile: {
+					email: "test@example.com",
+				},
+			} as User;
+			const context = buildContextForTest({ user });
+
+			// Act
+			await signin.call(context);
+
+			// Assert
+			expect(context.stdout).toContain(`Signed in as ${user.profile.email}`);
+			expect(context.exitCode).toBe(ExitCode.SUCCESS);
+		});
+	});
+
+	describe("when user is not signed in", () => {
+		test("informs the user they are signing in", async () => {
+			// Arrange
+			const context = buildContextForTest();
+
+			// Act
+			await signin.call(context);
+
+			// Assert
+			expect(context.stdout).toContain("Signing in...\n");
+		});
+
+		test("if the user signs in successfully", async () => {
+			// Arrange
+			const user = {
+				profile: {
+					email: "test@example.com",
+				},
+			} as User;
+
+			const context = buildContextForTest();
+			context.signIn = mock(() => Promise.resolve(user));
+
+			// Act
+			await signin.call(context);
+
+			// Assert
+			expect(context.stdout).toContain("Signing in...");
+			expect(context.stdout).toContain(`Signed in as ${user.profile.email}`);
+			expect(context.exitCode).toBe(ExitCode.SUCCESS);
+		});
+
+		test("if the user sign in fails", async () => {
+			// Arrange
+			const context = buildContextForTest();
+			context.signIn = mock(() => Promise.resolve(null));
+
+			// Act
+			await signin.call(context);
+
+			// Assert
+			expect(context.stdout).toContain("Signing in...");
+			expect(context.stderr).toContain("Sign in failed!");
+			expect(context.exitCode).toBe(ExitCode.FAILURE);
+		});
+
+		test("if the user sign in errors", async () => {
+			// Arrange
+			const context = buildContextForTest();
+			context.signIn = mock(() => Promise.reject(new Error("Sign in error")));
+
+			// Act
+			await signin.call(context);
+
+			// Assert
+			expect(context.stdout).toContain("Signing in...");
+			expect(context.stderr).toContain("Sign in errored!");
+			expect(context.exitCode).toBe(ExitCode.ERROR);
+		});
+	});
+});

--- a/tests/commands/auth/signout/signout.test.ts
+++ b/tests/commands/auth/signout/signout.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { signout } from "../../../../src/commands/auth/signout";
+import { ExitCode } from "../../../../src/types";
+import { buildContextForTest } from "../../../helpers/context.test";
+
+describe("auth signout", () => {
+	describe("when user is not signed in", () => {
+		test("informs the user they are not signed in", async () => {
+			// Arrange
+			const context = buildContextForTest({ user: null });
+
+			// Act
+			await signout.call(context);
+
+			// Assert
+			expect(context.stdout).toContain("Not signed in");
+			expect(context.exitCode).toBe(ExitCode.UNAUTHORIZED);
+		});
+	});
+
+	describe("when user is signed in", () => {
+		test("signs out successfully", async () => {
+			// Arrange
+			const user = {
+				profile: {
+					email: "test@example.com",
+				},
+			};
+			const context = buildContextForTest({ user });
+
+			// Act
+			await signout.call(context);
+
+			// Assert
+			expect(context.signOut).toHaveBeenCalled();
+			expect(context.stdout).toContain(`Signed out ${user.profile.email}`);
+			expect(context.exitCode).toBe(ExitCode.SUCCESS);
+		});
+	});
+});

--- a/tests/commands/auth/status/status.test.ts
+++ b/tests/commands/auth/status/status.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { status } from "../../../../src/commands/auth/status";
+import { ExitCode } from "../../../../src/types";
+import { buildContextForTest } from "../../../helpers/context.test";
+
+describe("auth status", () => {
+	describe("when user is not signed in", () => {
+		test("informs the user they are not signed in", async () => {
+			// Arrange
+			const context = buildContextForTest({ user: null });
+
+			// Act
+			await status.call(context);
+
+			// Assert
+			expect(context.stdout).toContain(
+				"Not Signed In\nRun 'pylee auth signin' to authenticate.\n",
+			);
+			expect(context.exitCode).toBe(ExitCode.UNAUTHORIZED);
+		});
+	});
+
+	describe("when user is signed in", () => {
+		test("signs out successfully", async () => {
+			// Arrange
+			const user = {
+				profile: {
+					email: "test@example.com",
+				},
+			};
+			const context = buildContextForTest({ user });
+
+			// Act
+			await status.call(context);
+
+			// Assert
+			expect(context.stdout).toContain(`Signed in as ${user.profile.email}`);
+			expect(context.exitCode).toBe(ExitCode.SUCCESS);
+		});
+	});
+});

--- a/tests/commands/proxy/proxy.test.ts
+++ b/tests/commands/proxy/proxy.test.ts
@@ -1,0 +1,67 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import proxy from "../../../src/commands/proxy/proxy";
+import type { User } from "../../../src/types";
+import { buildContextForTest } from "../../helpers/context.test";
+
+describe("proxy", () => {
+	const mockProxyServer = mock(() =>
+		Promise.resolve({ [Symbol.dispose]: mock(() => {}) }),
+	);
+
+	beforeAll(() => {
+		mock.module("@pyleeai/mcp-proxy-server", () => ({
+			MCPProxyServer: mockProxyServer,
+		}));
+	});
+
+	beforeEach(() => {
+		mockProxyServer.mockClear();
+	});
+
+	test("starts proxy with configured URL when user has configuration", async () => {
+		// Arrange
+		const user = {
+			profile: {
+				private_metadata: {
+					configurationUrl: "https://example.com/config",
+				},
+			},
+		} as unknown as User;
+		const context = buildContextForTest({ user });
+
+		// Act
+		await proxy.call(context);
+
+		// Assert
+		expect(context.user).toHaveBeenCalled();
+		expect(mockProxyServer).toHaveBeenCalledTimes(1);
+		expect(mockProxyServer).toHaveBeenCalledWith("https://example.com/config");
+	});
+
+	test("handles missing configuration URL gracefully", async () => {
+		// Arrange
+		const user = {} as User;
+		const context = buildContextForTest({ user });
+
+		// Act
+		await proxy.call(context);
+
+		// Assert
+		expect(context.user).toHaveBeenCalled();
+		expect(mockProxyServer).toHaveBeenCalledTimes(1);
+		expect(mockProxyServer).toHaveBeenCalledWith(undefined);
+	});
+
+	test("handles unauthenticated state gracefully", async () => {
+		// Arrange
+		const context = buildContextForTest();
+
+		// Act
+		await proxy.call(context);
+
+		// Assert
+		expect(context.user).toHaveBeenCalled();
+		expect(mockProxyServer).toHaveBeenCalledTimes(1);
+		expect(mockProxyServer).toHaveBeenCalledWith(undefined);
+	});
+});

--- a/tests/helpers/README.md
+++ b/tests/helpers/README.md
@@ -1,0 +1,58 @@
+# Test Helpers
+
+This directory contains utility files and helpers for use in tests that should be excluded from code coverage metrics.
+
+## Contents
+
+- `context.test.ts` - Provides a test-friendly implementation of the app context.
+
+## Usage
+
+### Context Helpers
+
+See [Mocking the Context](https://bloomberg.github.io/stricli/docs/testing#mocking-the-context).
+
+Import the context helper function from this directory when writing tests:
+
+```typescript
+import { buildContextForTest } from "../helpers/context.test";
+```
+
+Use it to build a context for testing:
+
+```typescript
+const context = buildContextForTest();
+```
+
+You can also set up the context with custom values:
+
+```typescript
+const context = buildContextForTest({
+  user: { id: 123, email: "test@example.com" },
+});
+```
+
+Then use it in tests:
+
+```typescript
+await sut.call(context);
+```
+
+#### Full example
+
+```typescript
+import { buildContextForTest } from "../helpers/context.test";
+import { module as sut } from "../path/to/module";
+
+describe("My Test Suite", () => {
+  it("should do something", async () => {
+    const context = buildContextForTest({
+      user: { id: 123, email: "test@example.com" },
+    });
+
+    await sut.call(context);
+
+    expect(context.user.id).toBe(123);
+  });
+});
+```

--- a/tests/helpers/context.test.ts
+++ b/tests/helpers/context.test.ts
@@ -1,0 +1,69 @@
+import { mock } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { LocalContext, User } from "../../src/types";
+
+export interface TestContext extends LocalContext {
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly exitCode?: number;
+	readonly reset: () => void;
+}
+
+export interface TestContextOptions {
+	user?: User | null;
+	readonly env?: Record<string, string>;
+}
+
+export function buildContextForTest(
+	options: TestContextOptions = {},
+): TestContext {
+	let stdout = "";
+	let stderr = "";
+	let exitCode: number | undefined;
+	const user = options.user ?? null;
+
+	const process = {
+		stdout: {
+			write: mock((arg: unknown) => {
+				stdout += String(arg);
+				return stdout;
+			}),
+		},
+		stderr: {
+			write: mock((arg: unknown) => {
+				stderr += String(arg);
+				return stderr;
+			}),
+		},
+		env: options.env,
+		exit: (code: number) => {
+			exitCode = code;
+		},
+	} as unknown as NodeJS.Process;
+
+	return {
+		os,
+		fs,
+		path,
+		process,
+		user: mock(async () => user),
+		signIn: mock(async () => user),
+		signOut: mock(async () => void 0),
+		get stdout() {
+			return stdout;
+		},
+		get stderr() {
+			return stderr;
+		},
+		get exitCode() {
+			return exitCode;
+		},
+		reset: () => {
+			stdout = "";
+			stderr = "";
+			exitCode = undefined;
+		},
+	};
+}


### PR DESCRIPTION
- Added `signin` and `signout` commands with success and error handling for user authentication.
- Implemented `status` command to display user sign-in state.
- Developed `proxy` command to connect to MCPProxyServer using user-configured URL, including tests.
- Introduced `ExitCode` enum for standardized exit codes.
- Added helper functions and documentation for testing CLI commands and context mocking.