### PR TITLE
feat: Add Deno support for GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: oven-sh/setup-bun@v2.0.1
-      - run: bun install
+      - uses: denoland/setup-deno@v2
+      - run: deno install
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
This change updates the GitHub Actions workflow to use Deno instead of
Bun. The `actions/checkout@v4` step remains the same, but the setup and
installation steps have been updated to use the `denoland/setup-deno@v2`
action and the `deno install` command, respectively. This allows the
project to leverage Deno's capabilities for the GoReleaser process.