### PR TITLE
env-types

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -10,6 +10,7 @@
     "npm:@stricli/core@1.1.2": "1.1.2",
     "npm:@stricli/core@^1.1.2": "1.1.2",
     "npm:@types/bun@latest": "1.2.13",
+    "npm:@types/node@*": "22.15.15",
     "npm:conf@13.1.0": "13.1.0_ajv@8.17.1",
     "npm:conf@^13.1.0": "13.1.0_ajv@8.17.1",
     "npm:oidc-client-ts@3.2.0": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@pyleeai/cli",
 	"projectName": "pylee",
 	"description": "Pylee AI CLI",
-	"version": "0.8.4",
+	"version": "0.8.5",
 	"license": "MIT",
 	"type": "module",
 	"module": "src/bin/cli.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,18 @@ import type { StricliAutoCompleteContext } from "@stricli/auto-complete";
 import type { CommandContext } from "@stricli/core";
 import type { IdTokenClaims, User as OidcUser } from "oidc-client-ts";
 
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      [key: string]: string | undefined;
+      PYLEE_OIDC_AUTHORITY: string
+      PYLEE_OIDC_CLIENT_ID: string
+      PYLEE_OIDC_REDIRECT_URI: string 
+      PYLEE_OIDC_PORT: string
+    }
+  }
+}
+
 export interface User extends Omit<OidcUser, "profile"> {
 	profile: IdTokenClaims & {
 		aud?: string | string[];


### PR DESCRIPTION
- Added new environment variables to the global `ProcessEnv` interface for OIDC configuration, including the authority, client ID, redirect URI, and port
- Added the `@types/node` dependency to provide type definitions for the Node.js runtime
- Bumped the version in the package.json file from 0.8.4 to 0.8.5