### PR TITLE
auto-sign-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@pyleeai/cli",
 	"projectName": "pylee",
 	"description": "Pylee AI CLI",
-	"version": "0.9.2",
+	"version": "0.9.3",
 	"license": "MIT",
 	"type": "module",
 	"module": "src/bin/cli.ts",

--- a/src/commands/auth/signin.ts
+++ b/src/commands/auth/signin.ts
@@ -1,23 +1,28 @@
-import type { LocalContext } from "../../types";
+import type { LocalContext, User } from "../../types";
 import { ExitCode } from "../../types";
 
 export async function signin(this: LocalContext): Promise<void> {
 	const user = await this.user();
 
-	this.process.stdout.write("Signing in...\n");
+	if (user) {
+		this.process.stdout.write(`Signed in as ${user.profile.email}\n`);
+		this.process.exit(ExitCode.SUCCESS);
+	} else {
+		this.process.stdout.write("Signing in...\n");
 
-	try {
-		const user = await this.signIn();
+		try {
+			const user = await this.signIn();
 
-		if (user) {
-			this.process.stdout.write(`Signed in as ${user.profile.email}\n`);
-			this.process.exit(ExitCode.SUCCESS);
-		} else {
-			this.process.stderr.write("Sign in failed!\n");
-			this.process.exit(ExitCode.FAILURE);
+			if (user) {
+				this.process.stdout.write(`Signed in as ${user.profile.email}\n`);
+				this.process.exit(ExitCode.SUCCESS);
+			} else {
+				this.process.stderr.write("Sign in failed!\n");
+				this.process.exit(ExitCode.FAILURE);
+			}
+		} catch {
+			this.process.stderr.write("Sign in errored!\n");
+			this.process.exit(ExitCode.ERROR);
 		}
-	} catch (error) {
-		this.process.stderr.write("Sign in errored!\n");
-		this.process.exit(ExitCode.ERROR);
 	}
 }

--- a/src/commands/proxy/proxy.ts
+++ b/src/commands/proxy/proxy.ts
@@ -1,11 +1,30 @@
 import { MCPProxyServer } from "@pyleeai/mcp-proxy-server";
-import type { LocalContext } from "../../types";
+import { ExitCode, type LocalContext } from "../../types.ts";
 
 export default async function (this: LocalContext): Promise<void> {
-	const user = await this.user();
-	const idToken = user?.id_token;
+	let user = await this.user();
+
+	if (!user) {
+		this.process.stdout.write("Signing in...\n");
+
+		try {
+			user = await this.signIn();
+
+			if (!user) {
+				this.process.stderr.write("Sign in failed!\n");
+				this.process.exit(ExitCode.FAILURE);
+				return;
+			}
+		} catch {
+			this.process.stderr.write("Sign in errored!\n");
+			this.process.exit(ExitCode.ERROR);
+			return;
+		}
+	}
+
+	const idToken = user.id_token;
 	const headers = { Authorization: `Bearer ${idToken}` };
-	const configurationUrl = user?.profile?.private_metadata?.configurationUrl;
+	const configurationUrl = user.profile?.private_metadata?.configurationUrl;
 
 	using proxy = await MCPProxyServer(configurationUrl, { headers });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,15 +6,15 @@ import type { CommandContext } from "@stricli/core";
 import type { IdTokenClaims, User as OidcUser } from "oidc-client-ts";
 
 declare global {
-  namespace NodeJS {
-    interface ProcessEnv {
-      [key: string]: string | undefined;
-      PYLEE_OIDC_AUTHORITY: string
-      PYLEE_OIDC_CLIENT_ID: string
-      PYLEE_OIDC_REDIRECT_URI: string 
-      PYLEE_OIDC_PORT: string
-    }
-  }
+	namespace NodeJS {
+		interface ProcessEnv {
+			[key: string]: string | undefined;
+			PYLEE_OIDC_AUTHORITY: string;
+			PYLEE_OIDC_CLIENT_ID: string;
+			PYLEE_OIDC_REDIRECT_URI: string;
+			PYLEE_OIDC_PORT: string;
+		}
+	}
 }
 
 export interface User extends Omit<OidcUser, "profile"> {

--- a/tests/commands/proxy/proxy.test.ts
+++ b/tests/commands/proxy/proxy.test.ts
@@ -96,7 +96,7 @@ describe("proxy", () => {
 		});
 	});
 
-	test("calls proxy with undefined config URL and token when user is null (unauthenticated)", async () => {
+	test("exits with failure when user is null and signIn fails", async () => {
 		// Arrange
 		const context = buildContextForTest({ user: null });
 
@@ -105,9 +105,9 @@ describe("proxy", () => {
 
 		// Assert
 		expect(context.user).toHaveBeenCalled();
-		expect(mockProxyServer).toHaveBeenCalledTimes(1);
-		expect(mockProxyServer).toHaveBeenCalledWith(undefined, {
-			headers: { Authorization: "Bearer undefined" },
-		});
+		expect(context.signIn).toHaveBeenCalled();
+		expect(context.exitCode).toBe(2); // FAILURE
+		expect(mockProxyServer).not.toHaveBeenCalled();
+		expect(context.stderr).toContain("Sign in failed!");
 	});
 });


### PR DESCRIPTION
# Description

- Added the `PYLEE_OIDC_PORT` environment variable to the `ProcessEnv` interface in the `types.ts` file to ensure the application can access the configured OIDC port from the environment.
- Improved the sign-in experience by adding a check to see if the user is already signed in before attempting to sign in again. If the user is already signed in, the command will simply print the user's email and exit successfully. If the user is not signed in, the command will attempt to sign in and handle the success or failure cases accordingly.
- Added sign-in logic to the proxy command to ensure the user is authenticated before starting the proxy server. This includes checking if the user is already signed in, and if not, prompting the user to sign in. If the sign-in fails, the command will exit with an appropriate error code.
- Bumped the package version from 0.9.2 to 0.9.3 in the package.json file to reflect the latest version of the Pylee AI CLI.