### PR TITLE
Retry auth

### DIFF
--- a/tests/commands/proxy/proxy.test.ts
+++ b/tests/commands/proxy/proxy.test.ts
@@ -215,7 +215,7 @@ describe("proxy", () => {
 		// Assert
 		expect(context.user).toHaveBeenCalled();
 		expect(mockProxyServer).toHaveBeenCalledTimes(1);
-		expect(context.stderr).toContain("Failed to initialize proxy");
+		expect(context.stderr).toContain("Proxy failed!");
 	});
 
 	test("handles MCPProxyServer failure with existing proxy running", async () => {
@@ -246,7 +246,7 @@ describe("proxy", () => {
 
 		// Assert
 		expect(mockProxyServer).toHaveBeenCalledTimes(2);
-		expect(context.stderr).toContain("Failed to initialize proxy");
+		expect(context.stderr).toContain("Proxy failed!");
 		expect(context.stderr).toContain("Keeping existing proxy running.");
 	});
 


### PR DESCRIPTION
Here is the pull request description based on the provided context:

```
## Changes

- Improved the handling of authentication errors in the proxy command, including retrying the request with fresh credentials when a 401 Unauthorized error occurs.
- Enhanced the error handling and retry logic for the proxy feature, such as retrying the proxy initialization when the initial call fails and handling the case where the re-authentication process fails.
- Simplified the error messages in the proxy command, making them more concise and informative.
- Updated the proxy server configuration to use the `CONFIGURATION_URL` environment variable instead of a hardcoded value, allowing for more flexibility in deployment.
- Improved the error handling and logging for the proxy command, providing better feedback to the user when issues occur with the proxy.
- Simplified the setup of signal handlers for the proxy command, ensuring that the cleanup function is properly called when the process is terminated.
```