### PR TITLE
Type fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "@pyleeai/cli",
       "dependencies": {
-        "@pyleeai/mcp-proxy-server": "0.9.0",
+        "@pyleeai/mcp-proxy-server": "0.9.2",
         "@stricli/auto-complete": "^1.1.2",
         "@stricli/core": "^1.1.2",
         "conf": "^13.1.0",
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "latest",
+        "@types/deno": "^2.3.0",
       },
       "peerDependencies": {
         "typescript": "^5.0.0",
@@ -41,13 +42,15 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.11.0", "", { "dependencies": { "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.3", "eventsource": "^3.0.2", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ=="],
 
-    "@pyleeai/mcp-proxy-server": ["@pyleeai/mcp-proxy-server@0.9.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.10.1", "zod": "^3.24.3" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "mcp-proxy-server": "build/main.js" } }, "sha512-AVCxP51gTNxzE61enmw2+bSm8bEGKfyW6jbvSAXBw41XoyiXaOQTFyvbo9pyZWRV1Y0ZWgmagmndpmDo4RyGuw=="],
+    "@pyleeai/mcp-proxy-server": ["@pyleeai/mcp-proxy-server@0.9.2", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.10.1", "zod": "^3.24.3" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "mcp-proxy-server": "build/main.js" } }, "sha512-2Gtt1RiJrfHXVAMCjg6FRZ/2YUVVDMTAblFnThEiLmTWN2DJLQzh3R2L5ZYE3G4G+/Gp09Lx3aY0nnYmRxO78Q=="],
 
     "@stricli/auto-complete": ["@stricli/auto-complete@1.1.2", "", { "dependencies": { "@stricli/core": "^1.1.2" }, "bin": { "auto-complete": "dist/bin/cli.js" } }, "sha512-sTNMh2bOvGH4meWSm4QCjbOCT1+8VSDbOkiOB6nYLaJZOr4CnWbn1s8N5h1GI6gMosUNP7waRr6FJVBhn/JfsQ=="],
 
     "@stricli/core": ["@stricli/core@1.1.2", "", {}, "sha512-/yWSoHUxo9mF8rgUyZkJgdrAoyIiOOhez1jo9vHTUJa8HTZYhioQUXtQU+rhi52m/hnV9Z2VGC2ap3OTH4NvUg=="],
 
     "@types/bun": ["@types/bun@1.2.11", "", { "dependencies": { "bun-types": "1.2.11" } }, "sha512-ZLbbI91EmmGwlWTRWuV6J19IUiUC5YQ3TCEuSHI3usIP75kuoA8/0PVF+LTrbEnVc8JIhpElWOxv1ocI1fJBbw=="],
+
+    "@types/deno": ["@types/deno@2.3.0", "", {}, "sha512-/4SyefQpKjwNKGkq9qG3Ln7MazfbWKvydyVFBnXzP5OQA4u1paoFtaOe1iHKycIWHHkhYag0lPxyheThV1ijzw=="],
 
     "@types/node": ["@types/node@22.15.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "@pyleeai/cli",
       "dependencies": {
-        "@pyleeai/mcp-proxy-server": "0.9.2",
+        "@pyleeai/mcp-proxy-server": "0.9.5",
         "@stricli/auto-complete": "^1.1.2",
         "@stricli/core": "^1.1.2",
         "conf": "^13.1.0",
@@ -42,7 +42,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.11.0", "", { "dependencies": { "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.3", "eventsource": "^3.0.2", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ=="],
 
-    "@pyleeai/mcp-proxy-server": ["@pyleeai/mcp-proxy-server@0.9.2", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.10.1", "zod": "^3.24.3" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "mcp-proxy-server": "build/main.js" } }, "sha512-2Gtt1RiJrfHXVAMCjg6FRZ/2YUVVDMTAblFnThEiLmTWN2DJLQzh3R2L5ZYE3G4G+/Gp09Lx3aY0nnYmRxO78Q=="],
+    "@pyleeai/mcp-proxy-server": ["@pyleeai/mcp-proxy-server@0.9.5", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.10.1", "zod": "^3.24.3" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "mcp-proxy-server": "build/main.js" } }, "sha512-lSxaw2zkHPNqfaDVw9Z+6OKd5w9VMjrSyKwJtwEdJ/LPsEBuuEm0UFz4sa9g8WM6tkPKlIB2BQ4Ev3Ykvzgrag=="],
 
     "@stricli/auto-complete": ["@stricli/auto-complete@1.1.2", "", { "dependencies": { "@stricli/core": "^1.1.2" }, "bin": { "auto-complete": "dist/bin/cli.js" } }, "sha512-sTNMh2bOvGH4meWSm4QCjbOCT1+8VSDbOkiOB6nYLaJZOr4CnWbn1s8N5h1GI6gMosUNP7waRr6FJVBhn/JfsQ=="],
 

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
 		"@std/assert": "jsr:@std/assert@1",
 		"@stricli/auto-complete": "npm:@stricli/auto-complete@1.1.2",
 		"@stricli/core": "npm:@stricli/core@1.1.2",
-		"@pyleeai/mcp-proxy-server": "npm:@pyleeai/mcp-proxy-server@0.9.2",
+		"@pyleeai/mcp-proxy-server": "npm:@pyleeai/mcp-proxy-server@0.9.3",
 		"conf": "npm:conf@13.1.0",
 		"oidc-client-ts": "npm:oidc-client-ts@3.2.0",
 		"open": "npm:open@10.1.2"

--- a/deno.lock
+++ b/deno.lock
@@ -10,6 +10,7 @@
     "npm:@stricli/core@1.1.2": "1.1.2",
     "npm:@stricli/core@^1.1.2": "1.1.2",
     "npm:@types/bun@latest": "1.2.13",
+    "npm:@types/deno@^2.3.0": "2.3.0",
     "npm:@types/node@*": "22.15.15",
     "npm:conf@13.1.0": "13.1.0_ajv@8.17.1",
     "npm:conf@^13.1.0": "13.1.0_ajv@8.17.1",
@@ -126,6 +127,9 @@
       "dependencies": [
         "bun-types"
       ]
+    },
+    "@types/deno@2.3.0": {
+      "integrity": "sha512-/4SyefQpKjwNKGkq9qG3Ln7MazfbWKvydyVFBnXzP5OQA4u1paoFtaOe1iHKycIWHHkhYag0lPxyheThV1ijzw=="
     },
     "@types/node@22.15.15": {
       "integrity": "sha512-R5muMcZob3/Jjchn5LcO8jdKwSCbzqmPB6ruBxMcf9kbxtniZHP327s6C37iOfuw8mbKK3cAQa7sEl7afLrQ8A==",
@@ -787,6 +791,7 @@
         "npm:@stricli/auto-complete@^1.1.2",
         "npm:@stricli/core@^1.1.2",
         "npm:@types/bun@latest",
+        "npm:@types/deno@^2.3.0",
         "npm:conf@^13.1.0",
         "npm:oidc-client-ts@^3.2.0",
         "npm:open@^10.1.2"

--- a/deno.lock
+++ b/deno.lock
@@ -4,7 +4,8 @@
     "jsr:@std/assert@1": "1.0.11",
     "jsr:@std/internal@^1.0.5": "1.0.7",
     "npm:@biomejs/biome@1.9.4": "1.9.4",
-    "npm:@pyleeai/mcp-proxy-server@0.9.2": "0.9.2_typescript@5.8.3",
+    "npm:@pyleeai/mcp-proxy-server@0.9.3": "0.9.3_typescript@5.8.3",
+    "npm:@pyleeai/mcp-proxy-server@0.9.5": "0.9.5_typescript@5.8.3",
     "npm:@stricli/auto-complete@1.1.2": "1.1.2",
     "npm:@stricli/auto-complete@^1.1.2": "1.1.2",
     "npm:@stricli/core@1.1.2": "1.1.2",
@@ -87,7 +88,7 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@modelcontextprotocol/sdk@1.12.0_express@5.1.0_zod@3.25.23": {
+    "@modelcontextprotocol/sdk@1.12.0_express@5.1.0_zod@3.25.28": {
       "integrity": "sha512-m//7RlINx1F3sz3KqwY1WWzVgTcYX52HYk4bJ1hkBXV3zccAEth+jRvG8DBRrdaQuRsPAJOx2MH3zaHNCKL7Zg==",
       "dependencies": [
         "ajv@6.12.6",
@@ -103,8 +104,17 @@
         "zod-to-json-schema"
       ]
     },
-    "@pyleeai/mcp-proxy-server@0.9.2_typescript@5.8.3": {
-      "integrity": "sha512-2Gtt1RiJrfHXVAMCjg6FRZ/2YUVVDMTAblFnThEiLmTWN2DJLQzh3R2L5ZYE3G4G+/Gp09Lx3aY0nnYmRxO78Q==",
+    "@pyleeai/mcp-proxy-server@0.9.3_typescript@5.8.3": {
+      "integrity": "sha512-Rhfm7PL1/KqTAX+qGSiD5XSbsiw7HLHOVrpqyNDZSIVZ2z9HTzA75vOgmYUW8LRq45VwY/h8GGv7dDQKHk6H7A==",
+      "dependencies": [
+        "@modelcontextprotocol/sdk",
+        "typescript",
+        "zod"
+      ],
+      "bin": true
+    },
+    "@pyleeai/mcp-proxy-server@0.9.5_typescript@5.8.3": {
+      "integrity": "sha512-lSxaw2zkHPNqfaDVw9Z+6OKd5w9VMjrSyKwJtwEdJ/LPsEBuuEm0UFz4sa9g8WM6tkPKlIB2BQ4Ev3Ykvzgrag==",
       "dependencies": [
         "@modelcontextprotocol/sdk",
         "typescript",
@@ -764,20 +774,20 @@
     "wrappy@1.0.2": {
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
-    "zod-to-json-schema@3.24.5_zod@3.25.23": {
+    "zod-to-json-schema@3.24.5_zod@3.25.28": {
       "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
       "dependencies": [
         "zod"
       ]
     },
-    "zod@3.25.23": {
-      "integrity": "sha512-Od2bdMosahjSrSgJtakrwjMDb1zM1A3VIHCPGveZt/3/wlrTWBya2lmEh2OYe4OIu8mPTmmr0gnLHIWQXdtWBg=="
+    "zod@3.25.28": {
+      "integrity": "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q=="
     }
   },
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@1",
-      "npm:@pyleeai/mcp-proxy-server@0.9.2",
+      "npm:@pyleeai/mcp-proxy-server@0.9.3",
       "npm:@stricli/auto-complete@1.1.2",
       "npm:@stricli/core@1.1.2",
       "npm:conf@13.1.0",
@@ -787,7 +797,7 @@
     "packageJson": {
       "dependencies": [
         "npm:@biomejs/biome@1.9.4",
-        "npm:@pyleeai/mcp-proxy-server@0.9.2",
+        "npm:@pyleeai/mcp-proxy-server@0.9.5",
         "npm:@stricli/auto-complete@^1.1.2",
         "npm:@stricli/core@^1.1.2",
         "npm:@types/bun@latest",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@pyleeai/cli",
 	"projectName": "pylee",
 	"description": "Pylee AI CLI",
-	"version": "0.9.4",
+	"version": "0.9.5",
 	"license": "MIT",
 	"type": "module",
 	"module": "src/bin/cli.ts",
@@ -25,7 +25,7 @@
 		"@types/deno": "^2.3.0"
 	},
 	"dependencies": {
-		"@pyleeai/mcp-proxy-server": "0.9.2",
+		"@pyleeai/mcp-proxy-server": "0.9.5",
 		"@stricli/auto-complete": "^1.1.2",
 		"@stricli/core": "^1.1.2",
 		"conf": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
-		"@types/bun": "latest"
+		"@types/bun": "latest",
+		"@types/deno": "^2.3.0"
 	},
 	"dependencies": {
 		"@pyleeai/mcp-proxy-server": "0.9.2",

--- a/src/commands/proxy/proxy.ts
+++ b/src/commands/proxy/proxy.ts
@@ -50,7 +50,7 @@ export default async function (this: LocalContext): Promise<void> {
 
 			try {
 				await this.signOut();
-				user = await this.signIn();
+				const user = await this.signIn();
 
 				if (!user) {
 					this.process.stderr.write("Sign in failed!\n");

--- a/src/commands/proxy/proxy.ts
+++ b/src/commands/proxy/proxy.ts
@@ -9,8 +9,6 @@ export default async function (this: LocalContext): Promise<void> {
 		let user = await this.user();
 
 		if (!user) {
-			this.process.stdout.write("Signing in...\n");
-
 			try {
 				user = await this.signIn();
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,7 +34,7 @@ export async function authServer(
 				}
 			},
 			onListen() {},
-			onError: (error) => {
+			onError: (error: unknown) => {
 				reject(error);
 				return new Response(errorHTML, { headers });
 			},

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ import {
 	PYLEE_OIDC_CLIENT_ID,
 	PYLEE_OIDC_REDIRECT_URI,
 } from "./env";
+import type { UserManagerSettings } from "oidc-client-ts";
 import { UserStore } from "./store";
 
 const userStore = new UserStore();
@@ -10,7 +11,7 @@ const authority = PYLEE_OIDC_AUTHORITY;
 const client_id = PYLEE_OIDC_CLIENT_ID;
 const redirect_uri = PYLEE_OIDC_REDIRECT_URI;
 
-export const settings = {
+export const settings: UserManagerSettings = {
 	authority,
 	client_id,
 	redirect_uri,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,9 +1,9 @@
+import type { UserManagerSettings } from "oidc-client-ts";
 import {
 	PYLEE_OIDC_AUTHORITY,
 	PYLEE_OIDC_CLIENT_ID,
 	PYLEE_OIDC_REDIRECT_URI,
 } from "./env";
-import type { UserManagerSettings } from "oidc-client-ts";
 import { UserStore } from "./store";
 
 const userStore = new UserStore();

--- a/tests/commands/proxy/proxy.test.ts
+++ b/tests/commands/proxy/proxy.test.ts
@@ -170,8 +170,9 @@ describe("proxy", () => {
 
 		// Act
 		await proxy.call(context);
-		const tokenExpiringHandler =
-			context.userManager.events.addAccessTokenExpiring.mock.calls[0][0];
+		const tokenExpiringHandler = (
+			context.userManager.events.addAccessTokenExpiring as any
+		).mock.calls[0][0];
 		await tokenExpiringHandler();
 
 		// Assert
@@ -207,14 +208,16 @@ describe("proxy", () => {
 			},
 		} as unknown as User;
 		const context = buildContextForTest({ user });
-		mockProxyServer.mockRejectedValueOnce(new Error("Proxy server failed"));
+		mockProxyServer
+			.mockRejectedValueOnce(new Error("Proxy server failed"))
+			.mockRejectedValueOnce(new Error("Retry also failed"));
 
 		// Act
 		await proxy.call(context);
 
 		// Assert
 		expect(context.user).toHaveBeenCalled();
-		expect(mockProxyServer).toHaveBeenCalledTimes(1);
+		expect(mockProxyServer).toHaveBeenCalledTimes(2);
 		expect(context.stderr).toContain("Proxy failed!");
 	});
 
@@ -231,21 +234,23 @@ describe("proxy", () => {
 		const context = buildContextForTest({ user });
 		const existingProxyDispose = mock(() => {});
 
-		// First call succeeds, second call fails
+		// First call succeeds, second call fails, third call also fails
 		mockProxyServer
 			.mockReturnValueOnce(
 				Promise.resolve({ [Symbol.dispose]: existingProxyDispose }),
 			)
-			.mockRejectedValueOnce(new Error("Proxy server failed"));
+			.mockRejectedValueOnce(new Error("Proxy server failed"))
+			.mockRejectedValueOnce(new Error("Retry also failed"));
 
 		// Act
 		await proxy.call(context);
-		const tokenExpiringHandler =
-			context.userManager.events.addAccessTokenExpiring.mock.calls[0][0];
+		const tokenExpiringHandler = (
+			context.userManager.events.addAccessTokenExpiring as any
+		).mock.calls[0][0];
 		await tokenExpiringHandler();
 
 		// Assert
-		expect(mockProxyServer).toHaveBeenCalledTimes(2);
+		expect(mockProxyServer).toHaveBeenCalledTimes(3);
 		expect(context.stderr).toContain("Proxy failed!");
 		expect(context.stderr).toContain("Keeping existing proxy running.");
 	});
@@ -261,7 +266,7 @@ describe("proxy", () => {
 			},
 		} as unknown as User;
 		const context = buildContextForTest({ user });
-		const mockOn = mock(() => {});
+		const mockOn = mock(() => {}) as any;
 		context.process.on = mockOn;
 
 		// Act
@@ -310,18 +315,18 @@ describe("proxy", () => {
 		mockProxyServer.mockReturnValue(
 			Promise.resolve({ [Symbol.dispose]: proxyDispose }),
 		);
-		const mockOn = mock(() => {});
+		const mockOn = mock(() => {}) as any;
 		context.process.on = mockOn;
 
 		// Act
 		await proxy.call(context);
 
 		// Get the cleanup function and call it
-		const cleanupFunction = mockOn.mock.calls.find(
-			(call) => call[0] === "SIGINT",
+		const cleanupFunction = (mockOn as any).mock.calls.find(
+			(call: any[]) => call[0] === "SIGINT",
 		)?.[1];
 		expect(cleanupFunction).toBeDefined();
-		cleanupFunction();
+		cleanupFunction?.();
 
 		// Assert
 		expect(context.exitCode).toBe(0); // SUCCESS
@@ -350,8 +355,9 @@ describe("proxy", () => {
 
 		// Act
 		await proxy.call(context);
-		const tokenExpiredHandler =
-			context.userManager.events.addAccessTokenExpired.mock.calls[0][0];
+		const tokenExpiredHandler = (
+			context.userManager.events.addAccessTokenExpired as any
+		).mock.calls[0][0];
 		await tokenExpiredHandler();
 
 		// Assert
@@ -381,11 +387,108 @@ describe("proxy", () => {
 
 		// Act
 		await proxy.call(context);
-		const silentRenewErrorHandler =
-			context.userManager.events.addSilentRenewError.mock.calls[0][0];
+		const silentRenewErrorHandler = (
+			context.userManager.events.addSilentRenewError as any
+		).mock.calls[0][0];
 		await silentRenewErrorHandler();
 
 		// Assert
 		expect(mockProxyServer).toHaveBeenCalledTimes(2); // Initial + restart from silent renew error event
+	});
+
+	test("handles proxy failure retry with signIn failure", async () => {
+		// Arrange
+		const user = {
+			id_token: "test-token-123",
+			profile: {
+				private_metadata: {
+					configurationUrl: "https://example.com/config",
+				},
+			},
+		} as unknown as User;
+		const context = buildContextForTest({ user });
+
+		// First MCPProxyServer call fails, then signIn returns null on retry
+		mockProxyServer.mockRejectedValueOnce(new Error("Proxy server failed"));
+		context.signIn = mock(() => Promise.resolve(null));
+
+		// Act
+		await proxy.call(context);
+
+		// Assert
+		expect(context.user).toHaveBeenCalled();
+		expect(context.signOut).toHaveBeenCalled();
+		expect(context.signIn).toHaveBeenCalled();
+		expect(context.stderr).toContain("Proxy failed, retrying...");
+		expect(context.stderr).toContain("Sign in failed!");
+		expect(mockProxyServer).toHaveBeenCalledTimes(1);
+	});
+
+	test("handles proxy failure retry with successful signIn and existing proxy", async () => {
+		// Arrange
+		const user = {
+			id_token: "test-token-123",
+			profile: {
+				private_metadata: {
+					configurationUrl: "https://example.com/config",
+				},
+			},
+		} as unknown as User;
+		const context = buildContextForTest({ user });
+		const existingProxyDispose = mock(() => {});
+		const retryProxyDispose = mock(() => {});
+
+		// First call succeeds (creates existing proxy), second call fails, retry succeeds
+		mockProxyServer
+			.mockReturnValueOnce(
+				Promise.resolve({ [Symbol.dispose]: existingProxyDispose }),
+			)
+			.mockRejectedValueOnce(new Error("Proxy server failed"))
+			.mockReturnValueOnce(
+				Promise.resolve({ [Symbol.dispose]: retryProxyDispose }),
+			);
+
+		// Act - initial proxy call
+		await proxy.call(context);
+
+		// Simulate token expiring which triggers retry logic
+		const tokenExpiringHandler = (
+			context.userManager.events.addAccessTokenExpiring as any
+		).mock.calls[0][0];
+		await tokenExpiringHandler();
+
+		// Assert
+		expect(context.signOut).toHaveBeenCalled();
+		expect(context.signIn).toHaveBeenCalled();
+		expect(context.stderr).toContain("Proxy failed, retrying...");
+		expect(mockProxyServer).toHaveBeenCalledTimes(3);
+		expect(existingProxyDispose).toHaveBeenCalledTimes(1);
+	});
+
+	test("handles proxy failure retry where both attempts fail with no existing proxy", async () => {
+		// Arrange
+		const user = {
+			id_token: "test-token-123",
+			profile: {
+				private_metadata: {
+					configurationUrl: "https://example.com/config",
+				},
+			},
+		} as unknown as User;
+		const context = buildContextForTest({ user });
+
+		// Both MCPProxyServer calls fail (initial and retry)
+		mockProxyServer
+			.mockRejectedValueOnce(new Error("Proxy server failed"))
+			.mockRejectedValueOnce(new Error("Retry also failed"));
+
+		// Act
+		await proxy.call(context);
+
+		// Assert
+		expect(context.stderr).toContain("Proxy failed, retrying...");
+		expect(context.stderr).toContain("Proxy failed!");
+		expect(context.stderr).not.toContain("Keeping existing proxy running.");
+		expect(mockProxyServer).toHaveBeenCalledTimes(2);
 	});
 });

--- a/tests/commands/proxy/proxy.test.ts
+++ b/tests/commands/proxy/proxy.test.ts
@@ -3,6 +3,12 @@ import proxy from "../../../src/commands/proxy/proxy";
 import type { User } from "../../../src/types";
 import { buildContextForTest } from "../../helpers/context.test";
 
+type MockFunction = {
+	mock: {
+		calls: unknown[][];
+	};
+};
+
 describe("proxy", () => {
 	const mockProxyServer = mock(() =>
 		Promise.resolve({ [Symbol.dispose]: mock(() => {}) }),
@@ -171,8 +177,9 @@ describe("proxy", () => {
 		// Act
 		await proxy.call(context);
 		const tokenExpiringHandler = (
-			context.userManager.events.addAccessTokenExpiring as any
-		).mock.calls[0][0];
+			context.userManager.events
+				.addAccessTokenExpiring as unknown as MockFunction
+		).mock.calls[0]?.[0] as () => void;
 		await tokenExpiringHandler();
 
 		// Assert
@@ -245,8 +252,9 @@ describe("proxy", () => {
 		// Act
 		await proxy.call(context);
 		const tokenExpiringHandler = (
-			context.userManager.events.addAccessTokenExpiring as any
-		).mock.calls[0][0];
+			context.userManager.events
+				.addAccessTokenExpiring as unknown as MockFunction
+		).mock.calls[0]?.[0] as () => void;
 		await tokenExpiringHandler();
 
 		// Assert
@@ -266,8 +274,8 @@ describe("proxy", () => {
 			},
 		} as unknown as User;
 		const context = buildContextForTest({ user });
-		const mockOn = mock(() => {}) as any;
-		context.process.on = mockOn;
+		const mockOn = mock(() => {}) as unknown as MockFunction;
+		(context.process as unknown as { on: MockFunction }).on = mockOn;
 
 		// Act
 		await proxy.call(context);
@@ -315,16 +323,16 @@ describe("proxy", () => {
 		mockProxyServer.mockReturnValue(
 			Promise.resolve({ [Symbol.dispose]: proxyDispose }),
 		);
-		const mockOn = mock(() => {}) as any;
-		context.process.on = mockOn;
+		const mockOn = mock(() => {}) as unknown as MockFunction;
+		(context.process as unknown as { on: MockFunction }).on = mockOn;
 
 		// Act
 		await proxy.call(context);
 
 		// Get the cleanup function and call it
-		const cleanupFunction = (mockOn as any).mock.calls.find(
-			(call: any[]) => call[0] === "SIGINT",
-		)?.[1];
+		const cleanupFunction = (mockOn as MockFunction).mock.calls.find(
+			(call: unknown[]) => call[0] === "SIGINT",
+		)?.[1] as (() => void) | undefined;
 		expect(cleanupFunction).toBeDefined();
 		cleanupFunction?.();
 
@@ -356,8 +364,9 @@ describe("proxy", () => {
 		// Act
 		await proxy.call(context);
 		const tokenExpiredHandler = (
-			context.userManager.events.addAccessTokenExpired as any
-		).mock.calls[0][0];
+			context.userManager.events
+				.addAccessTokenExpired as unknown as MockFunction
+		).mock.calls[0]?.[0] as () => void;
 		await tokenExpiredHandler();
 
 		// Assert
@@ -388,8 +397,8 @@ describe("proxy", () => {
 		// Act
 		await proxy.call(context);
 		const silentRenewErrorHandler = (
-			context.userManager.events.addSilentRenewError as any
-		).mock.calls[0][0];
+			context.userManager.events.addSilentRenewError as unknown as MockFunction
+		).mock.calls[0]?.[0] as () => void;
 		await silentRenewErrorHandler();
 
 		// Assert
@@ -453,8 +462,9 @@ describe("proxy", () => {
 
 		// Simulate token expiring which triggers retry logic
 		const tokenExpiringHandler = (
-			context.userManager.events.addAccessTokenExpiring as any
-		).mock.calls[0][0];
+			context.userManager.events
+				.addAccessTokenExpiring as unknown as MockFunction
+		).mock.calls[0]?.[0] as () => void;
 		await tokenExpiringHandler();
 
 		// Assert

--- a/tests/helpers/context.test.ts
+++ b/tests/helpers/context.test.ts
@@ -2,8 +2,8 @@ import { mock } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { LocalContext, User } from "../../src/types";
 import type { UserManager } from "oidc-client-ts";
+import type { LocalContext, User } from "../../src/types";
 
 type DeepPartial<T> = T extends object
 	? { [P in keyof T]?: DeepPartial<T[P]> }


### PR DESCRIPTION
# Description

## Key Changes

- Added the `@types/deno@^2.3.0` dependency to the `deno.lock` and `package.json` files to improve type support for the Deno runtime.
- Updated the version of the `@pyleeai/mcp-proxy-server` dependency in the `bun.lock` file from `0.9.0` to `0.9.2`.
- Introduced a `MockFunction` type to represent mocked functions with a `mock.calls` property, improving type safety and error handling in the proxy module.
- Improved the type safety of the `context.process.on` assignment by casting the `context.process` object to the appropriate type.
- Removed the unnecessary "Signing in..." message from the console output, providing a more seamless user experience.
- Updated the version of the `@pyleeai/mcp-proxy-server` dependency to `0.9.5` in the `package.json` and lock files, including bug fixes and improvements to the MCP proxy server.