### PR TITLE
feat(package): Bump version to 0.9.6-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@pyleeai/cli",
 	"projectName": "pylee",
 	"description": "Pylee AI CLI",
-	"version": "0.9.5",
+	"version": "0.9.6-rc.1",
 	"license": "MIT",
 	"type": "module",
 	"module": "src/bin/cli.ts",


### PR DESCRIPTION
Increase the version number in the package.json file from 0.9.5 to
0.9.6-rc.1. This change is necessary to prepare for the upcoming
release of version 0.9.6.