### PR TITLE
feat(package.json): Bump version to 0.9.6-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@pyleeai/cli",
 	"projectName": "pylee",
 	"description": "Pylee AI CLI",
-	"version": "0.9.6-rc.1",
+	"version": "0.9.6-rc.2",
 	"license": "MIT",
 	"type": "module",
 	"module": "src/bin/cli.ts",


### PR DESCRIPTION
The changes in this commit update the version number in the package.json
file from 0.9.6-rc.1 to 0.9.6-rc.2. This is a minor version bump to
indicate a new release candidate for the Pylee AI CLI.