### PR TITLE
Improved proxy error handling and authentication

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "@pyleeai/cli",
       "dependencies": {
-        "@pyleeai/mcp-proxy-server": "0.9.5",
+        "@pyleeai/mcp-proxy-server": "0.9.6",
         "@stricli/auto-complete": "^1.1.2",
         "@stricli/core": "^1.1.2",
         "conf": "^13.1.0",
@@ -42,7 +42,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.11.0", "", { "dependencies": { "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.3", "eventsource": "^3.0.2", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ=="],
 
-    "@pyleeai/mcp-proxy-server": ["@pyleeai/mcp-proxy-server@0.9.5", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.10.1", "zod": "^3.24.3" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "mcp-proxy-server": "build/main.js" } }, "sha512-lSxaw2zkHPNqfaDVw9Z+6OKd5w9VMjrSyKwJtwEdJ/LPsEBuuEm0UFz4sa9g8WM6tkPKlIB2BQ4Ev3Ykvzgrag=="],
+    "@pyleeai/mcp-proxy-server": ["@pyleeai/mcp-proxy-server@0.9.6", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.10.1", "zod": "^3.24.3" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "mcp-proxy-server": "build/main.js" } }, "sha512-WtfFb6/8UhaVuF86awh9VZZZydsimUdhqZBBTtLTOOXinc4GrfnYX8Mav3H4Po+z6ouJ3Ht63gn9bPwR45LyZw=="],
 
     "@stricli/auto-complete": ["@stricli/auto-complete@1.1.2", "", { "dependencies": { "@stricli/core": "^1.1.2" }, "bin": { "auto-complete": "dist/bin/cli.js" } }, "sha512-sTNMh2bOvGH4meWSm4QCjbOCT1+8VSDbOkiOB6nYLaJZOr4CnWbn1s8N5h1GI6gMosUNP7waRr6FJVBhn/JfsQ=="],
 

--- a/deno.lock
+++ b/deno.lock
@@ -5,7 +5,7 @@
     "jsr:@std/internal@^1.0.5": "1.0.7",
     "npm:@biomejs/biome@1.9.4": "1.9.4",
     "npm:@pyleeai/mcp-proxy-server@0.9.3": "0.9.3_typescript@5.8.3",
-    "npm:@pyleeai/mcp-proxy-server@0.9.5": "0.9.5_typescript@5.8.3",
+    "npm:@pyleeai/mcp-proxy-server@0.9.6": "0.9.6_typescript@5.8.3",
     "npm:@stricli/auto-complete@1.1.2": "1.1.2",
     "npm:@stricli/auto-complete@^1.1.2": "1.1.2",
     "npm:@stricli/core@1.1.2": "1.1.2",
@@ -113,8 +113,8 @@
       ],
       "bin": true
     },
-    "@pyleeai/mcp-proxy-server@0.9.5_typescript@5.8.3": {
-      "integrity": "sha512-lSxaw2zkHPNqfaDVw9Z+6OKd5w9VMjrSyKwJtwEdJ/LPsEBuuEm0UFz4sa9g8WM6tkPKlIB2BQ4Ev3Ykvzgrag==",
+    "@pyleeai/mcp-proxy-server@0.9.6_typescript@5.8.3": {
+      "integrity": "sha512-WtfFb6/8UhaVuF86awh9VZZZydsimUdhqZBBTtLTOOXinc4GrfnYX8Mav3H4Po+z6ouJ3Ht63gn9bPwR45LyZw==",
       "dependencies": [
         "@modelcontextprotocol/sdk",
         "typescript",
@@ -797,7 +797,7 @@
     "packageJson": {
       "dependencies": [
         "npm:@biomejs/biome@1.9.4",
-        "npm:@pyleeai/mcp-proxy-server@0.9.5",
+        "npm:@pyleeai/mcp-proxy-server@0.9.6",
         "npm:@stricli/auto-complete@^1.1.2",
         "npm:@stricli/core@^1.1.2",
         "npm:@types/bun@latest",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@pyleeai/cli",
 	"projectName": "pylee",
 	"description": "Pylee AI CLI",
-	"version": "0.9.6-rc.4",
+	"version": "0.9.6",
 	"license": "MIT",
 	"type": "module",
 	"module": "src/bin/cli.ts",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"@types/deno": "^2.3.0"
 	},
 	"dependencies": {
-		"@pyleeai/mcp-proxy-server": "0.9.5",
+		"@pyleeai/mcp-proxy-server": "0.9.6",
 		"@stricli/auto-complete": "^1.1.2",
 		"@stricli/core": "^1.1.2",
 		"conf": "^13.1.0",

--- a/tests/helpers/context.test.ts
+++ b/tests/helpers/context.test.ts
@@ -42,6 +42,7 @@ export function buildContextForTest(
 				return stderr;
 			}),
 		},
+		on: mock(() => {}),
 		env: options.env,
 		exit: (code: number) => {
 			exitCode = code;


### PR DESCRIPTION
Here is the pull request description based on the provided context:

```
## Changes

- Improved proxy error handling and authentication
  - Added an optional `forceRefresh` parameter to the `auth` function to force a fresh authentication when the existing user token is invalid
  - The `proxy` function now handles the case where the initial proxy creation fails by retrying with a fresh authentication
  - Updated error messages to provide more context and clarity on failure scenarios
  - Added a new test case to handle the scenario where the user's token is from a different authority
- Addressed handling of MCPProxyServer initialization failure
  - Updated the test case to handle the scenario where the proxy command will silently retry the initialization instead of displaying an error message
- Added a new `on` method to the mock child process object to allow for mocking event listeners on the child process
- Improved error handling and logging
  - Wrapped sign-in error messages with "Error:" prefix for consistency
  - Used `ExitCode.FAILURE` constant for sign-in error cases
  - Added missing newline to sign-in error message
  - Removed unnecessary test case for when `process.on` is not available
- Updated the `@pyleeai/mcp-proxy-server` dependency to version 0.9.6
- Simplified the proxy authentication and cleanup logic
  - Consolidated the `auth()` function to handle both user retrieval and sign-in
  - Refactored the `createProxy()` function to use the consolidated `auth()` function and handle the proxy creation and disposal more efficiently
  - Simplified the `proxy()` function to handle errors and call the `createProxy()` function with proper error handling
  - Improved the `cleanup()` function to use a more concise syntax for disposing the current proxy
  - Simplified the event listener setup to use a single success handler for all exit events
- Bumped the version to 0.9.6
```