### PR TITLE
Handle unhandled rejections as failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@pyleeai/cli",
 	"projectName": "pylee",
 	"description": "Pylee AI CLI",
-	"version": "0.9.7-rc.1",
+	"version": "0.9.7-rc.2",
 	"license": "MIT",
 	"type": "module",
 	"module": "src/bin/cli.ts",


### PR DESCRIPTION
- Improved error handling in the proxy command:
  - The `failure` function now takes an `Error` object for more detailed error reporting
  - Unhandled rejections are now handled by the `failure` function
  - Simplified error handling in the `createProxy` call
- Bumped version to 0.9.7-rc.2 in the package.json file