### PR TITLE
feat: update mcp-proxy-server and cli version

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
 		"@std/assert": "jsr:@std/assert@1",
 		"@stricli/auto-complete": "npm:@stricli/auto-complete@1.1.2",
 		"@stricli/core": "npm:@stricli/core@1.1.2",
-		"@pyleeai/mcp-proxy-server": "npm:@pyleeai/mcp-proxy-server@0.9.7-rc.1",
+		"@pyleeai/mcp-proxy-server": "npm:@pyleeai/mcp-proxy-server@0.9.9-rc.1",
 		"conf": "npm:conf@13.1.0",
 		"oidc-client-ts": "npm:oidc-client-ts@3.2.0",
 		"open": "npm:open@10.1.2"

--- a/deno.lock
+++ b/deno.lock
@@ -8,7 +8,6 @@
     "jsr:@std/internal@^1.0.5": "1.0.7",
     "jsr:@std/path@^1.0.6": "1.0.8",
     "npm:@biomejs/biome@1.9.4": "1.9.4",
-    "npm:@pyleeai/mcp-proxy-server@0.9.7-rc.1": "0.9.7-rc.1_typescript@5.8.3",
     "npm:@pyleeai/mcp-proxy-server@0.9.9-rc.1": "0.9.9-rc.1_typescript@5.8.3",
     "npm:@stricli/auto-complete@1.1.2": "1.1.2",
     "npm:@stricli/auto-complete@^1.1.2": "1.1.2",
@@ -250,15 +249,6 @@
         "zod",
         "zod-to-json-schema"
       ]
-    },
-    "@pyleeai/mcp-proxy-server@0.9.7-rc.1_typescript@5.8.3": {
-      "integrity": "sha512-gjKHfK/FVj6d/wI91xA0WjcqZn8hh8oxIRqXZtso4AWl2jYZdYje2hUd7cRzE6nNFZpx6XuXyNKhoBBoZnSnWg==",
-      "dependencies": [
-        "@modelcontextprotocol/sdk",
-        "typescript",
-        "zod"
-      ],
-      "bin": true
     },
     "@pyleeai/mcp-proxy-server@0.9.9-rc.1_typescript@5.8.3": {
       "integrity": "sha512-XJIPyHt8L5BInTf1g4Gm/ZKFvjo5JHSu5IBqgYR2E8lpPewsXkzUCo++bA1c3LGwidUDl1qvTajJjJVyUD0cHQ==",
@@ -966,7 +956,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@1",
-      "npm:@pyleeai/mcp-proxy-server@0.9.7-rc.1",
+      "npm:@pyleeai/mcp-proxy-server@0.9.9-rc.1",
       "npm:@stricli/auto-complete@1.1.2",
       "npm:@stricli/core@1.1.2",
       "npm:conf@13.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@pyleeai/cli",
 	"projectName": "pylee",
 	"description": "Pylee AI CLI",
-	"version": "0.9.9-rc.1",
+	"version": "0.9.9-rc.2",
 	"license": "MIT",
 	"type": "module",
 	"module": "src/bin/cli.ts",


### PR DESCRIPTION
Updates the version of the `@pyleeai/mcp-proxy-server` dependency to `0.9.9-rc.1` and the
version of the `@pyleeai/cli` package to `0.9.9-rc.2`. These changes are necessary to
incorporate the latest features and bug fixes in the proxy server and the CLI.